### PR TITLE
Revert change to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "taffydb-jsdoc",
+  "name": "taffydb",
   "version": "2.6.2",
   "description": "An open-source library that brings database features into your JavaScript applications.",
   "main": "taffy.js",


### PR DESCRIPTION
### Problem

[This commit](https://github.com/hegemonic/taffydb/commit/507d2d75fa16e1386f6d50abee1894b264d4458b) appears to have broken `npm install` for anyone using `gulp-jsdoc`:

```
npm ERR! Invalid Package: expected taffydb but found taffydb-jsdoc
npm ERR!
```
### Solution

Revert the change to the package name.

@hegemonic 
